### PR TITLE
Update nginxpwner.py

### DIFF
--- a/nginxpwner.py
+++ b/nginxpwner.py
@@ -55,7 +55,7 @@ else:
     print(f"{Fore.GREEN}[+] NGINX version is up to date")
 print(f"{Fore.BLUE}[?] If the tool reveals the nginx.conf file this is probably because there is no root directive in the nginx.conf file. Get the contents of the file and use https://github.com/yandex/gixy to find more misconfigurations")
 print(f"{Fore.WHITE}\n\n")
-os.system(f"gobuster dir -k --url '{url}' -w ./nginx.txt --wildcard --random-agent")
+os.system(f"gobuster -k -u '{url}' -w ./nginx.txt")
 print("\n")
 uri_crlf_test= requests.get(url+"/%0d%0aDetectify:%20clrf", verify=False)
 if "Detectify" in uri_crlf_test.headers:


### PR DESCRIPTION
gobuster keeps erroring.

```

2021/07/20 09:02:30 [!] 2 errors occurred:
	* WordList (-w): Must be specified (use `-w -` for stdin)
	* Url/Domain (-u): Must be specified
```

this fixes that.