### PR TITLE
Fix requests ssl certificate

### DIFF
--- a/nginxpwner.py
+++ b/nginxpwner.py
@@ -41,7 +41,7 @@ try:
 except:
   print(f"{Fore.RED}No Server header found or invalid Server header. If you are sure that your target uses Nginx, it may happen either you are testing something built with NGINX or that a simple NGINX server has the server_tokens directive set to off. In any case, please use nginx-pwner-no-server-header.py")
   sys.exit()
-nginx_req = requests.get(nginx_version)
+nginx_req = requests.get(nginx_version, verify=False)
 html=nginx_req.text
 soup = BeautifulSoup(html,'lxml')
 last_version =(soup.findAll('a', attrs={'href': re.compile("^/nginx/nginx/releases/tag")})[0].get('href')).split("-")[1]


### PR DESCRIPTION
Hello, 

I was trying to use the tool forwarding the traffic through a proxy and I found an issue
with a call to the requests API that checks for a valid certificate, as you can see in the below image.

![nginx-ssl-cert](https://github.com/stark0de/nginxpwner/assets/13271209/b65a82c7-2282-422a-8aac-94cb31d60574)

So I've just implemented the quick fix in this PR.

Thank you for the time you took writing the tool. 
Cya 